### PR TITLE
test: emphasize stores are not comparable

### DIFF
--- a/test/test_stdlib.py
+++ b/test/test_stdlib.py
@@ -23,6 +23,10 @@ class TestOpenSSLTrustStore(TestCase):
         system_store_explicit = stdlib.OpenSSLTrustStore(None)
         self.assertNotEqual(store, system_store_explicit)
 
+        # Separate instantiations of the same store (even the system store)
+        # are also not equal.
+        self.assertNotEqual(system_store, system_store_explicit)
+
 
 class TestOpenSSLTLSSocket(TestCase):
     def test_socket_init(self):


### PR DESCRIPTION
This should clarify https://github.com/trailofbits/tlslib.py/pull/11#discussion_r1541179858 -- the store equality tests are meant to trivially pass, since we _don't_ want users to compare stores. 