### PR TITLE
Change docstring wording for TrustStore

### DIFF
--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -626,7 +626,7 @@ class OpenSSLTrustStore:
     @classmethod
     def from_file(cls, path: os.PathLike) -> OpenSSLTrustStore:
         """
-        Initializes a trust store from a single file full of PEMs.
+        Initializes a trust store from a single file containing PEMs.
         """
 
         return cls(path=Path(path))

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -49,7 +49,7 @@ class TrustStore(Protocol):
     @classmethod
     def from_file(cls, path: os.PathLike) -> TrustStore:
         """
-        Initializes a trust store from a single file full of PEMs.
+        Initializes a trust store from a single file containing PEMs.
         """
         ...
 


### PR DESCRIPTION
Another suggestion, I find the wording:
> Initializes a trust store from a single file **full of PEMs**.

a bit weird, so this changes it. 