### PR TITLE
stdlib: Remove unreachable code

### DIFF
--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -475,9 +475,9 @@ class OpenSSLTLSSocket:
         for cipher in self._ssl_context.get_ciphers():
             if cipher["name"] == ossl_cipher:
                 break
-        else:
-            msg = "Unable to identify cipher suite"
-            raise TLSError(msg)
+        # Since the cipher was negotiated using the OpenSSL context,
+        # it must exist in the list of the OpenSSL supported ciphers.
+        assert cipher["name"] == ossl_cipher
 
         cipher_id = cipher["id"] & 0xFFFF
         try:


### PR DESCRIPTION
I _think_ that by the time you have an existing connection, whatever the cipher is that was negotiated, that cipher _must_ be present in the list of supported ciphers of the corresponding OpenSSL context.
This encodes that in an `assert`, rather than having an `else` condition that will never be reached.