### PR TITLE
Remove password interface for private keys and certificates

### DIFF
--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -190,16 +190,14 @@ def _configure_context_for_single_signing_chain(
             cert_path = Path(io.name)
 
         key_path = None
-        password = None
         if cert_chain.leaf[1] is not None:
             privkey = cert_chain.leaf[1]
             assert isinstance(privkey, OpenSSLPrivateKey)
             key_path = privkey._key_path
-            password = privkey._password
 
         assert cert_path is not None
         with _error_converter():
-            context.load_cert_chain(cert_path, key_path, password)
+            context.load_cert_chain(cert_path, key_path, None)
 
     return context
 
@@ -679,14 +677,13 @@ class OpenSSLPrivateKey:
     be used along with a certificate for either server or client connectivity.
     """
 
-    def __init__(self, path: os.PathLike, password: bytes | None = None):
+    def __init__(self, path: os.PathLike):
         """Creates a private key object, storing a path to the (temp)file."""
 
         self._key_path = path
-        self._password = password
 
     @classmethod
-    def from_buffer(cls, buffer: bytes, password: bytes | None = None) -> OpenSSLPrivateKey:
+    def from_buffer(cls, buffer: bytes) -> OpenSSLPrivateKey:
         """
         Creates a PrivateKey object from a byte buffer. This byte buffer
         may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -695,16 +692,6 @@ class OpenSSLPrivateKey:
         another series of dashes). In the absence of that preamble, the
         implementation may assume that the certificate is DER-encoded
         instead.
-
-        The key may additionally be encrypted. If it is, the ``password``
-        argument can be used to decrypt the key. The ``password`` argument
-        may be a function to call to get the password for decrypting the
-        private key. It will only be called if the private key is encrypted
-        and a password is necessary. It will be called with no arguments,
-        and it should return either bytes or bytearray containing the
-        password. Alternatively a bytes, or bytearray value may be supplied
-        directly as the password argument. It will be ignored if the
-        private key is not encrypted and no password is needed.
         """
 
         with tempfile.NamedTemporaryFile(mode="wb", delete=False) as io:
@@ -715,19 +702,16 @@ class OpenSSLPrivateKey:
         return key
 
     @classmethod
-    def from_file(cls, path: os.PathLike, password: bytes | None = None) -> OpenSSLPrivateKey:
+    def from_file(cls, path: os.PathLike) -> OpenSSLPrivateKey:
         """
         Creates a PrivateKey object from a file on disk. This method may
         be a convenience method that wraps ``open`` and ``from_buffer``,
         but some TLS implementations may be able to provide more-secure or
         faster methods of loading certificates that do not involve Python
         code.
-
-        The ``password`` parameter behaves exactly as the equivalent
-        parameter on ``from_buffer``.
         """
 
-        return cls(path=path, password=password)
+        return cls(path=path)
 
 
 #: The stdlib ``Backend`` object.

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -93,7 +93,7 @@ class PrivateKey(Protocol):
     for a certificate used in TLS."""
 
     @classmethod
-    def from_buffer(cls, buffer: bytes, password: bytes | None = None) -> PrivateKey:
+    def from_buffer(cls, buffer: bytes) -> PrivateKey:
         """
         Creates a PrivateKey object from a byte buffer. This byte buffer
         may be either PEM-encoded or DER-encoded. If the buffer is PEM
@@ -102,30 +102,17 @@ class PrivateKey(Protocol):
         another series of dashes). In the absence of that preamble, the
         implementation may assume that the certificate is DER-encoded
         instead.
-
-        The key may additionally be encrypted. If it is, the ``password``
-        argument can be used to decrypt the key. The ``password`` argument
-        may be a function to call to get the password for decrypting the
-        private key. It will only be called if the private key is encrypted
-        and a password is necessary. It will be called with no arguments,
-        and it should return either bytes or bytearray containing the
-        password. Alternatively a bytes, or bytearray value may be supplied
-        directly as the password argument. It will be ignored if the
-        private key is not encrypted and no password is needed.
         """
         raise NotImplementedError("Private Keys from buffers not supported")
 
     @classmethod
-    def from_file(cls, path: os.PathLike, password: bytes | None = None) -> PrivateKey:
+    def from_file(cls, path: os.PathLike) -> PrivateKey:
         """
         Creates a PrivateKey object from a file on disk. This method may
         be a convenience method that wraps ``open`` and ``from_buffer``,
         but some TLS implementations may be able to provide more-secure or
         faster methods of loading certificates that do not involve Python
         code.
-
-        The ``password`` parameter behaves exactly as the equivalent
-        parameter on ``from_buffer``.
         """
         raise NotImplementedError("Private Keys from buffers not supported")
 


### PR DESCRIPTION
Remove the password interface, because it violates separation of concerns and compels backends to support a something that’s orthogonal to TLS itself (PKCS#8 decapsulation with several very mediocre KDFs).