### PR TITLE
Adding support for system recommended settings

### DIFF
--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -298,9 +298,18 @@ def _init_context_common(
         config.inner_protocols,
     )
 
+    # In lieu of system recommended settings, we default to TLS v1.3
+    lowest_supported_version = config.lowest_supported_version
+    if lowest_supported_version is None:
+        lowest_supported_version = TLSVersion.TLSv1_3
+
+    highest_supported_version = config.highest_supported_version
+    if highest_supported_version is None:
+        highest_supported_version = TLSVersion.MAXIMUM_SUPPORTED
+
     try:
-        some_context.minimum_version = _TLSMinVersionOpts[config.lowest_supported_version]
-        some_context.maximum_version = _TLSMaxVersionOpts[config.highest_supported_version]
+        some_context.minimum_version = _TLSMinVersionOpts[lowest_supported_version]
+        some_context.maximum_version = _TLSMaxVersionOpts[highest_supported_version]
     except KeyError:
         raise TLSError("Bad maximum/minimum options")
 

--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import truststore
 
 from .tlslib import (
+    DEFAULT_CIPHER_LIST,
     Backend,
     CipherSuite,
     NextProtocol,
@@ -250,8 +251,12 @@ def _configure_context_for_ciphers(
 
     Returns the context.
     """
-    if ciphers is not None:
-        ossl_names = [_cipher_map[cipher] for cipher in ciphers if cipher in _cipher_map]
+    if ciphers is None:
+        # OpenSSL does not necessarily have system recommended settings
+        # The default cipher list is used here instead
+        ciphers = DEFAULT_CIPHER_LIST
+
+    ossl_names = [_cipher_map[cipher] for cipher in ciphers if cipher in _cipher_map]
     if not ossl_names:
         msg = "None of the provided ciphers are supported by the OpenSSL backend!"
         raise TLSError(msg)

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -9,6 +9,7 @@ from enum import Enum, IntEnum
 from typing import Generic, Protocol, TypeVar
 
 __all__ = [
+    "TLSBuffer",
     "TLSServerConfiguration",
     "TLSClientConfiguration",
     "ClientContext",
@@ -131,9 +132,10 @@ class TLSClientConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         and optionally a list of intermediate certificates. These certificates
         will be offered to the server during the handshake if required.
 
-    :param ciphers Sequence[CipherSuite | int]:
+    :param ciphers Sequence[CipherSuite | int] | None:
         The available ciphers for TLS connections created with this
-        configuration, in priority order.
+        configuration, in priority order. If None is provided, the backend
+        will choose a suitable default value (such as system recommended settings).
 
     :param inner_protocols Sequence[NextProtocol | bytes]:
         Protocols that connections created with this configuration should
@@ -166,15 +168,13 @@ class TLSClientConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
     def __init__(
         self,
         certificate_chain: SigningChain[_Certificate, _PrivateKey] | None = None,
-        ciphers: Sequence[CipherSuite] | None = None,
+        ciphers: Sequence[CipherSuite | int] | None = None,
         inner_protocols: Sequence[NextProtocol | bytes] | None = None,
         lowest_supported_version: TLSVersion | None = None,
         highest_supported_version: TLSVersion | None = None,
         trust_store: _TrustStore | None = None,
     ) -> None:
         """Initialize TLS client configuration."""
-        if ciphers is None:
-            ciphers = DEFAULT_CIPHER_LIST
 
         if inner_protocols is None:
             inner_protocols = []
@@ -203,8 +203,11 @@ class TLSClientConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         return self._certificate_chain
 
     @property
-    def ciphers(self) -> Sequence[CipherSuite | int]:
-        """The list of available ciphers for TLS connections, in priority order."""
+    def ciphers(self) -> Sequence[CipherSuite | int] | None:
+        """
+        The list of available ciphers for TLS connections, in priority order.
+        None indicates that system recommended settings will be used.
+        """
         return self._ciphers
 
     @property
@@ -246,9 +249,10 @@ class TLSServerConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         certificates. These certificates will be offered to the client during
         the handshake if required.
 
-    :param ciphers Sequence[CipherSuite | int]:
+    :param ciphers Sequence[CipherSuite | int] | None:
         The available ciphers for TLS connections created with this
-        configuration, in priority order.
+        configuration, in priority order. If None is provided, the backend
+        will choose a suitable default value (such as system recommended settings).
 
     :param inner_protocols Sequence[NextProtocol | bytes]:
         Protocols that connections created with this configuration should
@@ -289,8 +293,6 @@ class TLSServerConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         trust_store: _TrustStore | None = None,
     ) -> None:
         """Initialize TLS server configuration."""
-        if ciphers is None:
-            ciphers = DEFAULT_CIPHER_LIST
 
         if inner_protocols is None:
             inner_protocols = []
@@ -321,8 +323,11 @@ class TLSServerConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         return self._certificate_chain
 
     @property
-    def ciphers(self) -> Sequence[CipherSuite | int]:
-        """The list of available ciphers for TLS connections, in priority order."""
+    def ciphers(self) -> Sequence[CipherSuite | int] | None:
+        """
+        The list of available ciphers for TLS connections, in priority order.
+        None indicates that system recommended settings will be used.
+        """
         return self._ciphers
 
     @property

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -143,11 +143,11 @@ class TLSClientConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         advertised using ALPN. This list of protocols should be ordered
         by preference.
 
-    :param lowest_supported_version TLSVersion:
+    :param lowest_supported_version TLSVersion | None:
         The minimum version of TLS that should be allowed on TLS
         connections using this configuration.
 
-    :param highest_supported_version TLSVersion:
+    :param highest_supported_version TLSVersion | None:
         The maximum version of TLS that should be allowed on TLS
         connections using this configuration.
 
@@ -178,12 +178,6 @@ class TLSClientConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
 
         if inner_protocols is None:
             inner_protocols = []
-
-        if lowest_supported_version is None:
-            lowest_supported_version = TLSVersion.TLSv1_2
-
-        if highest_supported_version is None:
-            highest_supported_version = TLSVersion.MAXIMUM_SUPPORTED
 
         self._certificate_chain = certificate_chain
         self._ciphers = ciphers
@@ -219,13 +213,19 @@ class TLSClientConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         return self._inner_protocols
 
     @property
-    def lowest_supported_version(self) -> TLSVersion:
-        """The minimum version of TLS that is allowed on TLS connections."""
+    def lowest_supported_version(self) -> TLSVersion | None:
+        """
+        The minimum version of TLS that is allowed on TLS connections.
+        None indicates that system recommended settings will be used.
+        """
         return self._lowest_supported_version
 
     @property
-    def highest_supported_version(self) -> TLSVersion:
-        """The maximum version of TLS that will be allowed on TLS connections."""
+    def highest_supported_version(self) -> TLSVersion | None:
+        """
+        The maximum version of TLS that will be allowed on TLS connections.
+        None indicates that system recommended settings will be used.
+        """
         return self._highest_supported_version
 
     @property
@@ -260,11 +260,11 @@ class TLSServerConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         advertised using ALPN. This list of protocols should be ordered
         by preference.
 
-    :param lowest_supported_version TLSVersion:
+    :param lowest_supported_version TLSVersion | None:
         The minimum version of TLS that should be allowed on TLS
         connections using this configuration.
 
-    :param highest_supported_version TLSVersion:
+    :param highest_supported_version TLSVersion | None:
         The maximum version of TLS that should be allowed on TLS
         connections using this configuration.
 
@@ -296,12 +296,6 @@ class TLSServerConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
 
         if inner_protocols is None:
             inner_protocols = []
-
-        if lowest_supported_version is None:
-            lowest_supported_version = TLSVersion.TLSv1_2
-
-        if highest_supported_version is None:
-            highest_supported_version = TLSVersion.MAXIMUM_SUPPORTED
 
         self._certificate_chain = certificate_chain
         self._ciphers = ciphers
@@ -339,13 +333,19 @@ class TLSServerConfiguration(Generic[_TrustStore, _Certificate, _PrivateKey]):
         return self._inner_protocols
 
     @property
-    def lowest_supported_version(self) -> TLSVersion:
-        """The minimum version of TLS that is allowed on TLS connections."""
+    def lowest_supported_version(self) -> TLSVersion | None:
+        """
+        The minimum version of TLS that is allowed on TLS connections.
+        None indicates that system recommended settings will be used.
+        """
         return self._lowest_supported_version
 
     @property
-    def highest_supported_version(self) -> TLSVersion:
-        """The maximum version of TLS that will be allowed on TLS connections."""
+    def highest_supported_version(self) -> TLSVersion | None:
+        """
+        The maximum version of TLS that will be allowed on TLS connections.
+        None indicates that system recommended settings will be used.
+        """
         return self._highest_supported_version
 
     @property


### PR DESCRIPTION
This PR adds support for system recommended settings: In a TLS Configuration, the list of cipher suites can now be `None`, indicating that system recommended settings should be used. For the OpenSSL backend, this just means that the default cipher list will be used.