### PR TITLE
Add API support arbitrary identifiers for trust stores, certificates, and private keys

### DIFF
--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -949,6 +949,13 @@ class OpenSSLTrustStore:
 
         return cls(path=Path(path))
 
+    @classmethod
+    def from_id(cls, id: bytes) -> OpenSSLTrustStore:
+        """
+        Initializes a trust store from an arbitrary identifier.
+        """
+        raise NotImplementedError("Trust store from arbitrary identifier not supported")
+
 
 class OpenSSLCertificate:
     """A handle to a certificate object, either on disk or in a buffer, that can
@@ -987,6 +994,14 @@ class OpenSSLCertificate:
 
         return cls(path=path)
 
+    @classmethod
+    def from_id(cls, id: bytes) -> OpenSSLCertificate:
+        """
+        Creates a Certificate object from an arbitrary identifier. This may
+        be useful for backends that rely on system certificate stores.
+        """
+        raise NotImplementedError("Certificates from arbitrary identifiers not supported")
+
 
 class OpenSSLPrivateKey:
     """A handle to a private key object, either on disk or in a buffer, that can
@@ -1024,6 +1039,14 @@ class OpenSSLPrivateKey:
         """
 
         return cls(path=path)
+
+    @classmethod
+    def from_id(cls, id: bytes) -> OpenSSLPrivateKey:
+        """
+        Creates a PrivateKey object from an arbitrary identifier. This may
+        be useful for backends that rely on system private key stores.
+        """
+        raise NotImplementedError("Private Keys from arbitrary identifiers not supported")
 
 
 #: The stdlib ``Backend`` object.

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -53,6 +53,13 @@ class TrustStore(Protocol):
         """
         ...
 
+    @classmethod
+    def from_id(cls, id: bytes) -> TrustStore:
+        """
+        Initializes a trust store from an arbitrary identifier.
+        """
+        ...
+
 
 _TrustStore = TypeVar("_TrustStore", bound=TrustStore)
 
@@ -83,6 +90,14 @@ class Certificate(Protocol):
         code.
         """
         raise NotImplementedError("Certificates from files not supported")
+
+    @classmethod
+    def from_id(cls, id: bytes) -> Certificate:
+        """
+        Creates a Certificate object from an arbitrary identifier. This may
+        be useful for backends that rely on system certificate stores.
+        """
+        raise NotImplementedError("Certificates from arbitrary identifiers not supported")
 
 
 _Certificate = TypeVar("_Certificate", bound=Certificate)
@@ -115,6 +130,14 @@ class PrivateKey(Protocol):
         code.
         """
         raise NotImplementedError("Private Keys from buffers not supported")
+
+    @classmethod
+    def from_id(cls, id: bytes) -> PrivateKey:
+        """
+        Creates a PrivateKey object from an arbitrary identifier. This may
+        be useful for backends that rely on system private key stores.
+        """
+        raise NotImplementedError("Private Keys from arbitrary identifiers not supported")
 
 
 _PrivateKey = TypeVar("_PrivateKey", bound=PrivateKey)

--- a/test/test_stdlib.py
+++ b/test/test_stdlib.py
@@ -332,6 +332,17 @@ class TestNegative(TestBackend):
             with self.assertRaises(tlslib.WantWriteError):
                 client_sock.send(b"a" * 10000000)
 
+    def test_arbitrary_id_not_supported(self):
+        backend = stdlib.STDLIB_BACKEND
+
+        with self.assertRaises(NotImplementedError):
+            backend.trust_store.from_id(b"")
+        with self.assertRaises(NotImplementedError):
+            backend.certificate.from_id(b"")
+
+        with self.assertRaises(NotImplementedError):
+            backend.private_key.from_id(b"")
+
 
 class TestClientAgainstSSL(TestBackend):
     def test_trivial_connection_ssl(self):

--- a/test/test_tlslib.py
+++ b/test/test_tlslib.py
@@ -52,10 +52,16 @@ class AbstractFunctions(TestBackend):
             tlslib.Certificate.from_file("")
 
         with self.assertRaises(NotImplementedError):
+            tlslib.Certificate.from_id(b"")
+
+        with self.assertRaises(NotImplementedError):
             tlslib.PrivateKey.from_buffer(b"")
 
         with self.assertRaises(NotImplementedError):
             tlslib.PrivateKey.from_file("")
+
+        with self.assertRaises(NotImplementedError):
+            tlslib.PrivateKey.from_id(b"")
 
         with self.assertRaises(NotImplementedError):
             tlslib.TLSSocket.fileno(tlslib.TLSSocket)
@@ -63,6 +69,7 @@ class AbstractFunctions(TestBackend):
     def test_empty_protocols(self):
         tlslib.TrustStore.from_buffer(b"")
         tlslib.TrustStore.from_file("")
+        tlslib.TrustStore.from_id(b"")
         tlslib.TrustStore.system()
         tlslib.ClientContext.__init__(tlslib.ClientContext, tlslib.TLSClientConfiguration())
         tlslib.ServerContext.__init__(tlslib.ClientContext, tlslib.TLSServerConfiguration())


### PR DESCRIPTION
This PR adds API support for arbitrary identifiers for trust stores, certificates, and private keys.

The OpenSSL backend leaves these new APIs unimplemented.