### PR TITLE
Update getpeercert to return bytes

### DIFF
--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -448,18 +448,19 @@ class OpenSSLTLSSocket:
         with _error_converter():
             return self._socket.getsockname()
 
-    def getpeercert(self) -> OpenSSLCertificate | None:
-        """Return the certificate provided by the peer during the handshake, if applicable."""
+    def getpeercert(self) -> bytes | None:
+        """
+        Return the raw DER bytes of the certificate provided by the peer
+        during the handshake, if applicable.
+        """
         # In order to return an OpenSSLCertificate, we must obtain the certificate in binary format
         # Obtaining the certificate as a dict is very specific to the ssl module and may be
         # difficult to implement for other backends, so this is not supported
 
         with _error_converter():
             cert = self._socket.getpeercert(True)
-        if cert is None:
-            return None
-        else:
-            return OpenSSLCertificate.from_buffer(cert)
+
+        return cert
 
     def getpeername(self) -> socket._RetAddress:
         """Return the remote address to which the socket is connected."""
@@ -806,17 +807,18 @@ class OpenSSLTLSBuffer:
         else:
             return TLSVersion(ossl_version)
 
-    def getpeercert(self) -> OpenSSLCertificate | None:
-        """Return the certificate provided by the peer during the handshake, if applicable."""
+    def getpeercert(self) -> bytes | None:
+        """
+        Return the raw DER bytes of the certificate provided by the peer
+        during the handshake, if applicable.
+        """
         # In order to return an OpenSSLCertificate, we must obtain the certificate in binary format
         # Obtaining the certificate as a dict is very specific to the ssl module and may be
         # difficult to implement for other backends, so this is not supported
         with _error_converter():
             cert = self._object.getpeercert(True)
-        if cert is None:
-            return None
-        else:
-            return OpenSSLCertificate.from_buffer(cert)
+
+        return cert
 
 
 class OpenSSLClientContext:

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -463,8 +463,11 @@ class TLSSocket(Protocol):
         """Return the local address to which the socket is connected."""
 
     @abstractmethod
-    def getpeercert(self) -> Certificate | None:
-        """Return the certificate provided by the peer during the handshake, if applicable."""
+    def getpeercert(self) -> bytes | None:
+        """
+        Return the raw DER bytes of the certificate provided by the peer
+        during the handshake, if applicable.
+        """
 
     @abstractmethod
     def getpeername(self) -> tuple[str | None, int]:
@@ -648,6 +651,13 @@ class TLSBuffer(Protocol):
     def outgoing_bytes_buffered(self) -> int:
         """
         Returns how many bytes are in the outgoing buffer waiting to be sent.
+        """
+
+    @abstractmethod
+    def getpeercert(self) -> bytes | None:
+        """
+        Return the raw DER bytes of the certificate provided by the peer
+        during the handshake, if applicable.
         """
 
 

--- a/test/test_insecure.py
+++ b/test/test_insecure.py
@@ -82,7 +82,7 @@ class TestBasic(TestInsecureBackend):
             self.assertEqual(client_sock.cipher(), tlslib.CipherSuite.TLS_AES_256_GCM_SHA384)
             self.assertEqual(client_sock.negotiated_protocol(), None)
             self.assertEqual(client_sock.getpeername(), server.socket.getsockname())
-            self.assertIsInstance(client_sock.getpeercert(), stdlib_insecure.OpenSSLCertificate)
+            self.assertIsInstance(client_sock.getpeercert(), bytes)
             self.assertIsInstance(client_sock.fileno(), int)
             self.assertIsInstance(
                 insecure_client_context.insecure_configuration, insecure.InsecureConfiguration

--- a/test/test_stdlib.py
+++ b/test/test_stdlib.py
@@ -88,7 +88,7 @@ class TestBasic(TestBackend):
             self.assertEqual(client_sock.cipher(), tlslib.CipherSuite.TLS_AES_256_GCM_SHA384)
             self.assertEqual(client_sock.negotiated_protocol(), None)
             self.assertEqual(client_sock.getpeername(), server.socket.getsockname())
-            self.assertIsInstance(client_sock.getpeercert(), stdlib.OpenSSLCertificate)
+            self.assertIsInstance(client_sock.getpeercert(), bytes)
             self.assertIsInstance(client_sock.fileno(), int)
 
             while True:
@@ -355,7 +355,7 @@ class TestClientAgainstSSL(TestBackend):
             self.assertEqual(client_sock.cipher(), tlslib.CipherSuite.TLS_AES_256_GCM_SHA384)
             self.assertEqual(client_sock.negotiated_protocol(), None)
             self.assertEqual(client_sock.getpeername(), server.socket.getsockname())
-            self.assertIsInstance(client_sock.getpeercert(), stdlib.OpenSSLCertificate)
+            self.assertIsInstance(client_sock.getpeercert(), bytes)
             self.assertIsInstance(client_sock.fileno(), int)
 
             client_sock.close(True)


### PR DESCRIPTION
There is no reason for the peer cert to be returned as a `Certificate` type, because those are only used as input of the API. Raw DER-encoded bytes are returned instead. 