### PR TITLE
Pure types for trust store, certificates, and private keys

### DIFF
--- a/src/tlslib/insecure/__init__.py
+++ b/src/tlslib/insecure/__init__.py
@@ -2,17 +2,15 @@
 
 import warnings
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import Generic, Protocol, TypeVar
 
 from ..tlslib import (
     Backend,
-    Certificate,
     ClientContext,
-    PrivateKey,
     ServerContext,
     TLSClientConfiguration,
     TLSServerConfiguration,
-    TrustStore,
 )
 
 
@@ -126,9 +124,6 @@ class InsecureServerContext(ServerContext, Protocol):
         """The insecure configuration options that will make this context insecure."""
 
 
-_TrustStore = TypeVar("_TrustStore", bound=TrustStore)
-_Certificate = TypeVar("_Certificate", bound=Certificate)
-_PrivateKey = TypeVar("_PrivateKey", bound=PrivateKey)
 _ClientContext = TypeVar("_ClientContext", bound=ClientContext)
 _ServerContext = TypeVar("_ServerContext", bound=ServerContext)
 _InsecureClientContext = TypeVar("_InsecureClientContext", bound=InsecureClientContext)
@@ -146,26 +141,11 @@ class InsecureBackend(Backend, Generic[_InsecureClientContext, _InsecureServerCo
         "_insecure_server_context",
     )
 
-    @property
-    def insecure_configuration(
-        self,
-    ) -> type[InsecureConfiguration]:
-        """
-        Returns a type object for `InsecureConfiguration`.
-
-        This is identical to using `InsecureConfiguration` directly, and
-        is just here for consistency with the Generic-based TLSClientConfiguration
-        and TLSServerConfiguration in the regular Backend.
-        """
-        return InsecureConfiguration
-
     def __init__(
         self,
-        certificate: type[_Certificate],
         client_context: type[_ClientContext],
-        private_key: type[_PrivateKey],
         server_context: type[_ServerContext],
-        trust_store: type[_TrustStore],
+        validate_config: Callable[[TLSClientConfiguration | TLSServerConfiguration], None],
         insecure_client_context: type[_InsecureClientContext],
         insecure_server_context: type[_InsecureServerContext],
     ) -> None:
@@ -180,11 +160,9 @@ class InsecureBackend(Backend, Generic[_InsecureClientContext, _InsecureServerCo
         self._insecure_server_context = insecure_server_context
 
         super().__init__(
-            certificate=certificate,
             client_context=client_context,
-            private_key=private_key,
             server_context=server_context,
-            trust_store=trust_store,
+            validate_config=validate_config,
         )
 
     @property

--- a/src/tlslib/insecure/stdlib_insecure.py
+++ b/src/tlslib/insecure/stdlib_insecure.py
@@ -13,13 +13,11 @@ from ..stdlib import (
     _init_context_client,
     _init_context_server,
     _SSLContext,
+    validate_config,
 )
 from ..tlslib import (
-    Certificate,
-    PrivateKey,
     TLSClientConfiguration,
     TLSServerConfiguration,
-    TrustStore,
 )
 from . import (
     InsecureBackend,
@@ -177,11 +175,9 @@ class OpenSSLInsecureServerContext(OpenSSLServerContext):
 
 #: The stdlib ``InsecureBackend`` object.
 STDLIB_INSECURE_BACKEND = InsecureBackend(
-    certificate=Certificate,
     client_context=OpenSSLClientContext,
-    private_key=PrivateKey,
     server_context=OpenSSLServerContext,
-    trust_store=TrustStore,
+    validate_config=validate_config,
     insecure_client_context=OpenSSLInsecureClientContext,
     insecure_server_context=OpenSSLInsecureServerContext,
 )

--- a/src/tlslib/insecure/stdlib_insecure.py
+++ b/src/tlslib/insecure/stdlib_insecure.py
@@ -6,20 +6,20 @@ import ssl
 import warnings
 
 from ..stdlib import (
-    OpenSSLCertificate,
     OpenSSLClientContext,
-    OpenSSLPrivateKey,
     OpenSSLServerContext,
     OpenSSLTLSBuffer,
     OpenSSLTLSSocket,
-    OpenSSLTrustStore,
     _init_context_client,
     _init_context_server,
     _SSLContext,
 )
 from ..tlslib import (
+    Certificate,
+    PrivateKey,
     TLSClientConfiguration,
     TLSServerConfiguration,
+    TrustStore,
 )
 from . import (
     InsecureBackend,
@@ -177,11 +177,11 @@ class OpenSSLInsecureServerContext(OpenSSLServerContext):
 
 #: The stdlib ``InsecureBackend`` object.
 STDLIB_INSECURE_BACKEND = InsecureBackend(
-    certificate=OpenSSLCertificate,
+    certificate=Certificate,
     client_context=OpenSSLClientContext,
-    private_key=OpenSSLPrivateKey,
+    private_key=PrivateKey,
     server_context=OpenSSLServerContext,
-    trust_store=OpenSSLTrustStore,
+    trust_store=TrustStore,
     insecure_client_context=OpenSSLInsecureClientContext,
     insecure_server_context=OpenSSLInsecureServerContext,
 )

--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -19,6 +19,7 @@ from .tlslib import (
     Backend,
     Certificate,
     CipherSuite,
+    ConfigurationError,
     NextProtocol,
     PrivateKey,
     RaggedEOF,
@@ -103,7 +104,7 @@ def _get_path_from_trust_store(
         weakref.finalize(context, _remove_path, trust_store)
         return trust_store._path
     elif trust_store._id is not None:
-        raise NotImplementedError("This backend does not support id-based trust stores.")
+        raise ConfigurationError("This backend does not support id-based trust stores.")
     else:
         return None
 
@@ -216,12 +217,12 @@ def _get_path_from_cert_or_priv(
         weakref.finalize(context, _remove_path, cert_or_priv)
         return cert_or_priv._path
     elif cert_or_priv._id is not None:
-        raise NotImplementedError(
+        raise ConfigurationError(
             "This backend does not support id-based certificates \
                                   or private keys."
         )
     else:
-        raise ValueError("Certificate or PrivateKey cannot be empty.")
+        raise ConfigurationError("Certificate or PrivateKey cannot be empty.")
 
 
 def _get_bytes_from_cert(cert: Certificate) -> bytes:
@@ -231,9 +232,9 @@ def _get_bytes_from_cert(cert: Certificate) -> bytes:
         # Do not save cert in memory
         return Path(cert._path).read_bytes()
     elif cert._id is not None:
-        raise NotImplementedError("This backend does not support id-based certificates.")
+        raise ConfigurationError("This backend does not support id-based certificates.")
     else:
-        raise ValueError("Certificate cannot be empty.")
+        raise ConfigurationError("Certificate cannot be empty.")
 
 
 def _configure_context_for_single_signing_chain(
@@ -283,9 +284,9 @@ def _configure_context_for_sni(
     sni_config: TLSServerConfiguration,
 ) -> ssl.SSLContext:
     # This is a mapping of concrete server names to the corresponding SigningChain
-    _name_to_chain_map: weakref.WeakValueDictionary[
-        str, SigningChain
-    ] = weakref.WeakValueDictionary()
+    _name_to_chain_map: weakref.WeakValueDictionary[str, SigningChain] = (
+        weakref.WeakValueDictionary()
+    )
 
     for sign_chain in cert_chain:
         # Parse leaf certificates to find server names
@@ -995,17 +996,17 @@ def _check_cert_or_priv(cert_or_priv: Certificate | PrivateKey) -> None:
     if cert_or_priv._path is not None or cert_or_priv._buffer is not None:
         return None
     elif cert_or_priv._id is not None:
-        raise NotImplementedError(
+        raise ConfigurationError(
             "This backend does not support id-based certificates \
                                   or private keys."
         )
     else:
-        raise ValueError("Certificate or PrivateKey cannot be empty.")
+        raise ConfigurationError("Certificate or PrivateKey cannot be empty.")
 
 
 def _check_trust_store(trust_store: TrustStore | None) -> None:
     if trust_store is not None and trust_store._id is not None:
-        raise NotImplementedError("This backend does not support id-based trust stores.")
+        raise ConfigurationError("This backend does not support id-based trust stores.")
 
 
 def _check_sign_chain(sign_chain: SigningChain) -> None:

--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -215,7 +215,10 @@ def _get_path_from_cert_or_priv(
         weakref.finalize(context, _remove_path, cert_or_priv)
         return cert_or_priv._path
     elif cert_or_priv._id is not None:
-        raise NotImplementedError("This backend does not support id-based certificates.")
+        raise NotImplementedError(
+            "This backend does not support id-based certificates \
+                                  or private keys."
+        )
     else:
         raise ValueError("Certificate or PrivateKey cannot be empty.")
 
@@ -244,7 +247,6 @@ def _configure_context_for_single_signing_chain(
 
     if cert_chain is not None:
         cert = cert_chain.leaf[0]
-        # assert isinstance(cert, OpenSSLCertificate)
 
         if len(cert_chain.chain) == 0:
             cert_path = _get_path_from_cert_or_priv(context, cert)
@@ -255,8 +257,6 @@ def _configure_context_for_single_signing_chain(
                 io.write(_get_bytes_from_cert(cert))
 
                 for cert in cert_chain.chain:
-                    # TODO: Typecheck this properly.
-                    # assert isinstance(cert, OpenSSLCertificate)
                     io.write(b"\n")
                     io.write(_get_bytes_from_cert(cert))
 
@@ -289,7 +289,6 @@ def _configure_context_for_sni(
     for sign_chain in cert_chain:
         # Parse leaf certificates to find server names
         cert = sign_chain.leaf[0]
-        # assert isinstance(cert, OpenSSLCertificate)
         cert_path = _get_path_from_cert_or_priv(context, cert)
         dec_cert = ssl._ssl._test_decode_cert(cert_path)  # type: ignore[attr-defined]
 
@@ -982,7 +981,10 @@ def _check_cert_or_priv(cert_or_priv: Certificate | PrivateKey) -> None:
     if cert_or_priv._path is not None or cert_or_priv._buffer is not None:
         return None
     elif cert_or_priv._id is not None:
-        raise NotImplementedError("This backend does not support id-based certificates.")
+        raise NotImplementedError(
+            "This backend does not support id-based certificates \
+                                  or private keys."
+        )
     else:
         raise ValueError("Certificate or PrivateKey cannot be empty.")
 

--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -283,9 +283,9 @@ def _configure_context_for_sni(
     sni_config: TLSServerConfiguration,
 ) -> ssl.SSLContext:
     # This is a mapping of concrete server names to the corresponding SigningChain
-    _name_to_chain_map: weakref.WeakValueDictionary[str, SigningChain] = (
-        weakref.WeakValueDictionary()
-    )
+    _name_to_chain_map: weakref.WeakValueDictionary[
+        str, SigningChain
+    ] = weakref.WeakValueDictionary()
 
     for sign_chain in cert_chain:
         # Parse leaf certificates to find server names

--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -990,12 +990,8 @@ def _check_cert_or_priv(cert_or_priv: Certificate | PrivateKey) -> None:
 
 
 def _check_trust_store(trust_store: TrustStore | None) -> None:
-    if trust_store is None or trust_store._path is not None or trust_store._buffer is not None:
-        return None
-    elif trust_store._id is not None:
+    if trust_store is not None and trust_store._id is not None:
         raise NotImplementedError("This backend does not support id-based trust stores.")
-    else:
-        return None
 
 
 def _check_sign_chain(sign_chain: SigningChain) -> None:

--- a/src/tlslib/stdlib.py
+++ b/src/tlslib/stdlib.py
@@ -949,6 +949,13 @@ class OpenSSLTrustStore:
 
         return cls(path=Path(path))
 
+    @classmethod
+    def from_id(cls, id: bytes) -> OpenSSLTrustStore:
+        """
+        Initializes a trust store from an arbitrary identifier.
+        """
+        raise NotImplementedError("Trust store from arbitrary identifier not supported")
+
 
 class OpenSSLCertificate:
     """A handle to a certificate object, either on disk or in a buffer, that can
@@ -987,6 +994,14 @@ class OpenSSLCertificate:
 
         return cls(path=path)
 
+    @classmethod
+    def from_id(cls, id: bytes) -> OpenSSLCertificate:
+        """
+        Creates a Certificate object from an arbitrary identifier. This may
+        be useful for backends that rely on system certificate stores.
+        """
+        raise NotImplementedError("Certificates from arbitrary identifiers not supported")
+
 
 class OpenSSLPrivateKey:
     """A handle to a private key object, either on disk or in a buffer, that can
@@ -1024,6 +1039,14 @@ class OpenSSLPrivateKey:
         """
 
         return cls(path=path)
+
+    @classmethod
+    def from_id(cls, id: bytes) -> OpenSSLPrivateKey:
+        """
+        Creates a PrivateKey object from an arbitrary identifier. This may
+        be useful for backends that rely on system private key stores.
+        """
+        raise NotImplementedError("Private Keys from arbitrary identifiers not supported")
 
 
 #: The stdlib ``Backend`` object.

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -871,6 +871,11 @@ class RaggedEOF(TLSError):
     """
 
 
+class ConfigurationError(TLSError):
+    """An special exception that backends can use when the provided
+    configuration uses features not supported by that backend."""
+
+
 class SigningChain:
     """Object representing a certificate chain used in TLS."""
 

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -53,6 +53,13 @@ class TrustStore(Protocol):
         """
         ...
 
+    @classmethod
+    def from_id(cls, id: bytes) -> TrustStore:
+        """
+        Initializes a trust store from an arbitrary identifier.
+        """
+        ...
+
 
 _TrustStore = TypeVar("_TrustStore", bound=TrustStore)
 
@@ -83,6 +90,14 @@ class Certificate(Protocol):
         code.
         """
         raise NotImplementedError("Certificates from files not supported")
+
+    @classmethod
+    def from_id(cls, id: bytes) -> Certificate:
+        """
+        Creates a Certificate object from an arbitrary identifier. This may
+        be useful for backends that rely on system certificate stores.
+        """
+        raise NotImplementedError("Certificates from arbitrary identifiers not supported")
 
 
 _Certificate = TypeVar("_Certificate", bound=Certificate)
@@ -115,6 +130,14 @@ class PrivateKey(Protocol):
         code.
         """
         raise NotImplementedError("Private Keys from buffers not supported")
+
+    @classmethod
+    def from_id(cls, id: bytes) -> PrivateKey:
+        """
+        Creates a PrivateKey object from an arbitrary identifier. This may
+        be useful for backends that rely on system private key stores.
+        """
+        raise NotImplementedError("Private Keys from arbitrary identifiers not supported")
 
 
 _PrivateKey = TypeVar("_PrivateKey", bound=PrivateKey)

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -122,11 +122,13 @@ class Certificate:
     @classmethod
     def from_file(cls, path: os.PathLike) -> Certificate:
         """
-        Creates a Certificate object from a file on disk. This method may
-        be a convenience method that wraps ``open`` and ``from_buffer``,
-        but some TLS implementations may be able to provide more-secure or
-        faster methods of loading certificates that do not involve Python
-        code.
+        Creates a Certificate object from a file on disk. The file on disk
+        should contain a series of bytes corresponding to a certificate that
+        may be either PEM-encoded or DER-encoded. If the bytes are PEM encoded
+        it *must* begin with the standard PEM preamble (a series of dashes
+        followed by the ASCII bytes "BEGIN CERTIFICATE" and another series of
+        dashes). In the absence of that preamble, the implementation may
+        assume that the certificate is DER-encoded instead.
         """
         return cls(path=path)
 
@@ -173,7 +175,7 @@ class PrivateKey:
         encoded it *must* begin with the standard PEM preamble (a series of
         dashes followed by the ASCII bytes "BEGIN", the key type, and
         another series of dashes). In the absence of that preamble, the
-        implementation may assume that the certificate is DER-encoded
+        implementation may assume that the private key is DER-encoded
         instead.
         """
         return cls(buffer=buffer)
@@ -181,11 +183,13 @@ class PrivateKey:
     @classmethod
     def from_file(cls, path: os.PathLike) -> PrivateKey:
         """
-        Creates a PrivateKey object from a file on disk. This method may
-        be a convenience method that wraps ``open`` and ``from_buffer``,
-        but some TLS implementations may be able to provide more-secure or
-        faster methods of loading certificates that do not involve Python
-        code.
+        Creates a PrivateKey object from a file on disk. The file on disk
+        should contain a series of bytes corresponding to a certificate that
+        may be either PEM-encoded or DER-encoded. If the bytes are PEM encoded
+        it *must* begin with the standard PEM preamble (a series of dashes
+        followed by the ASCII bytes "BEGIN", the key type, and another series
+        of dashes). In the absence of that preamble, the implementation may
+        assume that the certificate is DER-encoded instead.
         """
         return cls(path=path)
 

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -26,10 +26,29 @@ __all__ = [
 ]
 
 
-class TrustStore(Protocol):
+class TrustStore:
     """
     The trust store that is used to verify certificate validity.
     """
+
+    __slots__ = (
+        "_buffer",
+        "_path",
+        "_id",
+    )
+
+    def __init__(
+        self, buffer: bytes | None = None, path: os.PathLike | None = None, id: bytes | None = None
+    ):
+        """
+        Creates a TrustStore object from a path, buffer, or ID.
+
+        If none of these is given, the default system trust store is used.
+        """
+
+        self._buffer = buffer
+        self._path = path
+        self._id = id
 
     @classmethod
     def system(cls) -> TrustStore:
@@ -37,35 +56,57 @@ class TrustStore(Protocol):
         Returns a TrustStore object that represents the system trust
         database.
         """
-        ...
+        return cls()
 
     @classmethod
     def from_buffer(cls, buffer: bytes) -> TrustStore:
         """
         Initializes a trust store from a buffer of PEM-encoded certificates.
         """
-        ...
+        return cls(buffer=buffer)
 
     @classmethod
     def from_file(cls, path: os.PathLike) -> TrustStore:
         """
         Initializes a trust store from a single file containing PEMs.
         """
-        ...
+        return cls(path=path)
 
     @classmethod
     def from_id(cls, id: bytes) -> TrustStore:
         """
         Initializes a trust store from an arbitrary identifier.
         """
-        ...
+        return cls(id=id)
 
 
 _TrustStore = TypeVar("_TrustStore", bound=TrustStore)
 
 
-class Certificate(Protocol):
+class Certificate:
     """Object representing a certificate used in TLS."""
+
+    __slots__ = (
+        "_buffer",
+        "_path",
+        "_id",
+    )
+
+    def __init__(
+        self, buffer: bytes | None = None, path: os.PathLike | None = None, id: bytes | None = None
+    ):
+        """
+        Creates a Certificate object from a path, buffer, or ID.
+
+        If none of these is given, an exception is raised.
+        """
+
+        if buffer is None and path is None and id is None:
+            raise ValueError("Certificate cannot be empty.")
+
+        self._buffer = buffer
+        self._path = path
+        self._id = id
 
     @classmethod
     def from_buffer(cls, buffer: bytes) -> Certificate:
@@ -78,7 +119,7 @@ class Certificate(Protocol):
         implementation may assume that the certificate is DER-encoded
         instead.
         """
-        raise NotImplementedError("Certificates from buffers not supported")
+        return cls(buffer=buffer)
 
     @classmethod
     def from_file(cls, path: os.PathLike) -> Certificate:
@@ -89,7 +130,7 @@ class Certificate(Protocol):
         faster methods of loading certificates that do not involve Python
         code.
         """
-        raise NotImplementedError("Certificates from files not supported")
+        return cls(path=path)
 
     @classmethod
     def from_id(cls, id: bytes) -> Certificate:
@@ -97,15 +138,37 @@ class Certificate(Protocol):
         Creates a Certificate object from an arbitrary identifier. This may
         be useful for backends that rely on system certificate stores.
         """
-        raise NotImplementedError("Certificates from arbitrary identifiers not supported")
+        return cls(id=id)
 
 
 _Certificate = TypeVar("_Certificate", bound=Certificate)
 
 
-class PrivateKey(Protocol):
+class PrivateKey:
     """Object representing a private key corresponding to a public key
     for a certificate used in TLS."""
+
+    __slots__ = (
+        "_buffer",
+        "_path",
+        "_id",
+    )
+
+    def __init__(
+        self, buffer: bytes | None = None, path: os.PathLike | None = None, id: bytes | None = None
+    ):
+        """
+        Creates a PrivateKey object from a path, buffer, or ID.
+
+        If none of these is given, an exception is raised.
+        """
+
+        if buffer is None and path is None and id is None:
+            raise ValueError("PrivateKey cannot be empty.")
+
+        self._buffer = buffer
+        self._path = path
+        self._id = id
 
     @classmethod
     def from_buffer(cls, buffer: bytes) -> PrivateKey:
@@ -118,7 +181,7 @@ class PrivateKey(Protocol):
         implementation may assume that the certificate is DER-encoded
         instead.
         """
-        raise NotImplementedError("Private Keys from buffers not supported")
+        return cls(buffer=buffer)
 
     @classmethod
     def from_file(cls, path: os.PathLike) -> PrivateKey:
@@ -129,7 +192,7 @@ class PrivateKey(Protocol):
         faster methods of loading certificates that do not involve Python
         code.
         """
-        raise NotImplementedError("Private Keys from buffers not supported")
+        return cls(path=path)
 
     @classmethod
     def from_id(cls, id: bytes) -> PrivateKey:
@@ -137,7 +200,7 @@ class PrivateKey(Protocol):
         Creates a PrivateKey object from an arbitrary identifier. This may
         be useful for backends that rely on system private key stores.
         """
-        raise NotImplementedError("Private Keys from arbitrary identifiers not supported")
+        return cls(id=id)
 
 
 _PrivateKey = TypeVar("_PrivateKey", bound=PrivateKey)

--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -248,13 +248,8 @@ class TLSClientConfiguration:
 
     def __init__(
         self,
-<<<<<<< jp/puretypes
         certificate_chain: SigningChain | None = None,
         ciphers: Sequence[CipherSuite] | None = None,
-=======
-        certificate_chain: SigningChain[_Certificate, _PrivateKey] | None = None,
-        ciphers: Sequence[CipherSuite | int] | None = None,
->>>>>>> main
         inner_protocols: Sequence[NextProtocol | bytes] | None = None,
         lowest_supported_version: TLSVersion | None = None,
         highest_supported_version: TLSVersion | None = None,

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -17,17 +17,16 @@ from tlslib.insecure import InsecureConfiguration
 from tlslib.insecure.stdlib_insecure import STDLIB_INSECURE_BACKEND
 from tlslib.stdlib import (
     STDLIB_BACKEND,
-    OpenSSLCertificate,
-    OpenSSLPrivateKey,
-    OpenSSLTrustStore,
     TLSVersion,
 )
 from tlslib.tlslib import (
     DEFAULT_CIPHER_LIST,
     Backend,
+    Certificate,
     CipherSuite,
     ClientContext,
     NextProtocol,
+    PrivateKey,
     RaggedEOF,
     ServerContext,
     SigningChain,
@@ -36,6 +35,7 @@ from tlslib.tlslib import (
     TLSError,
     TLSServerConfiguration,
     TLSSocket,
+    TrustStore,
     WantReadError,
     WantWriteError,
 )
@@ -255,13 +255,13 @@ def limbo_server(id: str) -> tuple[ThreadedEchoServer, TLSClientConfiguration]:
 
     testcase = limbo_asset(id)
 
-    peer_cert = OpenSSLCertificate.from_buffer(testcase["peer_certificate"].encode())
+    peer_cert = Certificate.from_buffer(testcase["peer_certificate"].encode())
     peer_cert_key = None
     if testcase["peer_certificate_key"] is not None:
-        peer_cert_key = OpenSSLPrivateKey.from_buffer(testcase["peer_certificate_key"].encode())
+        peer_cert_key = PrivateKey.from_buffer(testcase["peer_certificate_key"].encode())
     untrusted_intermediates = []
     for pem in testcase["untrusted_intermediates"]:
-        untrusted_intermediates.append(OpenSSLCertificate.from_buffer(pem.encode()))
+        untrusted_intermediates.append(Certificate.from_buffer(pem.encode()))
     signing_chain = SigningChain(leaf=(peer_cert, peer_cert_key), chain=untrusted_intermediates)
 
     trusted_certs = []
@@ -292,12 +292,12 @@ def limbo_server(id: str) -> tuple[ThreadedEchoServer, TLSClientConfiguration]:
 
 def tweak_client_config(
     old_config: TLSClientConfiguration,
-    certificate_chain: SigningChain[OpenSSLCertificate, OpenSSLPrivateKey] | None = None,
+    certificate_chain: SigningChain[Certificate, PrivateKey] | None = None,
     ciphers: Sequence[CipherSuite | int] | None = None,
     inner_protocols: Sequence[NextProtocol | bytes] | None = None,
     lowest_supported_version: TLSVersion | None = None,
     highest_supported_version: TLSVersion | None = None,
-    trust_store: OpenSSLTrustStore | None = None,
+    trust_store: TrustStore | None = None,
 ) -> TLSClientConfiguration:
     if certificate_chain is None:
         certificate_chain = old_config.certificate_chain
@@ -329,12 +329,12 @@ def tweak_client_config(
 
 def tweak_server_config(
     server: ThreadedEchoServer,
-    certificate_chain: Sequence[SigningChain[OpenSSLCertificate, OpenSSLPrivateKey]] | None = None,
+    certificate_chain: Sequence[SigningChain[Certificate, PrivateKey]] | None = None,
     ciphers: Sequence[CipherSuite | int] | None = None,
     inner_protocols: Sequence[NextProtocol | bytes] | None = None,
     lowest_supported_version: TLSVersion | None = None,
     highest_supported_version: TLSVersion | None = None,
-    trust_store: OpenSSLTrustStore | None = None,
+    trust_store: TrustStore | None = None,
     insecure_config: InsecureConfiguration | None = None,
 ) -> ThreadedEchoServer:
     old_config = server.server_context.configuration
@@ -403,15 +403,13 @@ def limbo_server_ssl(
     server_trust_store = None
     if client_id is not None:
         testcase_client = limbo_asset(client_id)
-        peer_cert = OpenSSLCertificate.from_buffer(testcase_client["peer_certificate"].encode())
+        peer_cert = Certificate.from_buffer(testcase_client["peer_certificate"].encode())
         peer_cert_key = None
         if testcase_client["peer_certificate_key"] is not None:
-            peer_cert_key = OpenSSLPrivateKey.from_buffer(
-                testcase_client["peer_certificate_key"].encode()
-            )
+            peer_cert_key = PrivateKey.from_buffer(testcase_client["peer_certificate_key"].encode())
         untrusted_intermediates = []
         for pem in testcase_client["untrusted_intermediates"]:
-            untrusted_intermediates.append(OpenSSLCertificate.from_buffer(pem.encode()))
+            untrusted_intermediates.append(Certificate.from_buffer(pem.encode()))
         sign_chain_client = SigningChain(
             leaf=(peer_cert, peer_cert_key), chain=untrusted_intermediates
         )

--- a/test/_utils.py
+++ b/test/_utils.py
@@ -123,7 +123,7 @@ class ThreadedEchoServer(threading.Thread):
         self.server_context: ServerContext | ssl.SSLContext
         if backend is not None:
             self.backend = backend
-            server_configuration = backend.server_configuration(
+            server_configuration = TLSServerConfiguration(
                 certificate_chain=cert_chain,
                 ciphers=ciphers,
                 inner_protocols=inner_protocols,
@@ -250,7 +250,7 @@ class ThreadedEchoServer(threading.Thread):
 def limbo_server(id: str) -> tuple[ThreadedEchoServer, TLSClientConfiguration]:
     """
     Return a `ThreadedServer` and a `TLSClientConfiguration` suitable for connecting to it,
-    both instantiated with an `sslib` backend and state from the given Limbo testcase.
+    both instantiated with an `tlslib` backend and state from the given Limbo testcase.
     """
 
     testcase = limbo_asset(id)
@@ -268,13 +268,13 @@ def limbo_server(id: str) -> tuple[ThreadedEchoServer, TLSClientConfiguration]:
     for pem in testcase["trusted_certs"]:
         trusted_certs.append(pem.encode())
 
-    client_config = STDLIB_BACKEND.client_configuration(
+    client_config = TLSClientConfiguration(
         certificate_chain=None,
         ciphers=DEFAULT_CIPHER_LIST,
         inner_protocols=None,
         lowest_supported_version=TLSVersion.MINIMUM_SUPPORTED,
         highest_supported_version=TLSVersion.MAXIMUM_SUPPORTED,
-        trust_store=STDLIB_BACKEND.trust_store.from_buffer(b"\n".join(trusted_certs)),
+        trust_store=TrustStore.from_buffer(b"\n".join(trusted_certs)),
     )
 
     server = ThreadedEchoServer(
@@ -379,8 +379,9 @@ def limbo_server_ssl(
     id: str, client_id: str | None = None
 ) -> tuple[ThreadedEchoServer, TLSClientConfiguration]:
     """
-    Return a `ThreadedServer` and a `TLSClientConfiguration` suitable for connecting to it,
-    both instantiated with an `sslib` backend and state from the given Limbo testcase.
+    Return a `ThreadedServer` with an `ssl` backend and a `TLSClientConfiguration`
+    suitable for connecting to it, both instantiated with a state from the given
+    Limbo testcase.
     """
 
     testcase = limbo_asset(id)
@@ -424,13 +425,13 @@ def limbo_server_ssl(
                 io_client.write(b"\n")
         server_trust_store = Path(io_client.name)
 
-    client_config = STDLIB_BACKEND.client_configuration(
+    client_config = TLSClientConfiguration(
         certificate_chain=sign_chain_client,
         ciphers=DEFAULT_CIPHER_LIST,
         inner_protocols=None,
         lowest_supported_version=TLSVersion.MINIMUM_SUPPORTED,
         highest_supported_version=TLSVersion.MAXIMUM_SUPPORTED,
-        trust_store=STDLIB_BACKEND.trust_store.from_buffer(b"\n".join(trusted_certs)),
+        trust_store=TrustStore.from_buffer(b"\n".join(trusted_certs)),
     )
 
     protocols = []

--- a/test/test_insecure.py
+++ b/test/test_insecure.py
@@ -28,9 +28,9 @@ class TestInsecureBackend(TestCase):
     def test_insecure_backend_types(self):
         insecure_backend = stdlib_insecure.STDLIB_INSECURE_BACKEND
 
-        self.assertIs(insecure_backend.certificate, stdlib_insecure.OpenSSLCertificate)
+        self.assertIs(insecure_backend.certificate, stdlib_insecure.Certificate)
         self.assertIs(insecure_backend.client_context, stdlib_insecure.OpenSSLClientContext)
-        self.assertIs(insecure_backend.private_key, stdlib_insecure.OpenSSLPrivateKey)
+        self.assertIs(insecure_backend.private_key, stdlib_insecure.PrivateKey)
         self.assertIs(insecure_backend.server_context, stdlib_insecure.OpenSSLServerContext)
         self.assertIs(
             insecure_backend.insecure_client_context, stdlib_insecure.OpenSSLInsecureClientContext
@@ -82,7 +82,7 @@ class TestBasic(TestInsecureBackend):
             self.assertEqual(client_sock.cipher(), tlslib.CipherSuite.TLS_AES_256_GCM_SHA384)
             self.assertEqual(client_sock.negotiated_protocol(), None)
             self.assertEqual(client_sock.getpeername(), server.socket.getsockname())
-            self.assertIsInstance(client_sock.getpeercert(), stdlib_insecure.OpenSSLCertificate)
+            self.assertIsInstance(client_sock.getpeercert(), stdlib_insecure.Certificate)
             self.assertIsInstance(client_sock.fileno(), int)
             self.assertIsInstance(
                 insecure_client_context.insecure_configuration, insecure.InsecureConfiguration

--- a/test/test_insecure.py
+++ b/test/test_insecure.py
@@ -10,7 +10,7 @@ with warnings.catch_warnings():
         "ignore",
         message="Using an InsecureBackend is insecure. This should not be used in production.",
     )
-    from tlslib import insecure, tlslib
+    from tlslib import insecure, stdlib, tlslib
     from tlslib.insecure import SecurityWarning, stdlib_insecure
 
     from ._utils import (
@@ -28,9 +28,7 @@ class TestInsecureBackend(TestCase):
     def test_insecure_backend_types(self):
         insecure_backend = stdlib_insecure.STDLIB_INSECURE_BACKEND
 
-        self.assertIs(insecure_backend.certificate, stdlib_insecure.Certificate)
         self.assertIs(insecure_backend.client_context, stdlib_insecure.OpenSSLClientContext)
-        self.assertIs(insecure_backend.private_key, stdlib_insecure.PrivateKey)
         self.assertIs(insecure_backend.server_context, stdlib_insecure.OpenSSLServerContext)
         self.assertIs(
             insecure_backend.insecure_client_context, stdlib_insecure.OpenSSLInsecureClientContext
@@ -40,9 +38,7 @@ class TestInsecureBackend(TestCase):
         )
 
         # invariant properties
-        self.assertIs(insecure_backend.client_configuration, tlslib.TLSClientConfiguration)
-        self.assertIs(insecure_backend.server_configuration, tlslib.TLSServerConfiguration)
-        self.assertIs(insecure_backend.insecure_configuration, insecure.InsecureConfiguration)
+        self.assertIs(insecure_backend.validate_config, stdlib.validate_config)
 
 
 class TestBasic(TestInsecureBackend):
@@ -52,9 +48,7 @@ class TestBasic(TestInsecureBackend):
         # Overwrite client TrustStore to remove needed root certificate
         new_client_config = tweak_client_config(client_config, trust_store=None)
         with self.assertWarns(SecurityWarning):
-            insecure_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.insecure_configuration(
-                True, True
-            )
+            insecure_config = insecure.InsecureConfiguration(True, True)
 
         with server:
             with self.assertWarns(SecurityWarning):
@@ -109,12 +103,10 @@ class TestBasic(TestInsecureBackend):
         server, client_config = limbo_server("webpki::san::exact-localhost-ip-san")
 
         # Enable client auth by setting a TrustStore
-        truststore = stdlib_insecure.STDLIB_INSECURE_BACKEND.trust_store.system()
+        truststore = tlslib.TrustStore.system()
 
         with self.assertWarns(SecurityWarning):
-            insecure_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.insecure_configuration(
-                True, True
-            )
+            insecure_config = insecure.InsecureConfiguration(True, True)
 
         with self.assertWarns(SecurityWarning):
             server = tweak_server_config(
@@ -141,7 +133,7 @@ class TestBasic(TestInsecureBackend):
     def test_invalid_insecure_config(self):
         with self.assertRaises(ValueError):
             with self.assertWarns(SecurityWarning):
-                _ = stdlib_insecure.STDLIB_INSECURE_BACKEND.insecure_configuration(False, True)
+                _ = insecure.InsecureConfiguration(False, True)
 
 
 class TestBuffer(TestInsecureBackend):
@@ -153,9 +145,7 @@ class TestBuffer(TestInsecureBackend):
         # Overwrite client TrustStore to remove needed root certificate
         new_client_config = tweak_client_config(client_config, trust_store=None)
         with self.assertWarns(SecurityWarning):
-            insecure_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.insecure_configuration(
-                True, True
-            )
+            insecure_config = insecure.InsecureConfiguration(True, True)
 
         hostname = "localhost"
 
@@ -189,13 +179,11 @@ class TestBuffer(TestInsecureBackend):
         loop_until_success(client_buffer, server_buffer, "shutdown")
 
     def test_create_client_buffer_insecure(self):
-        client_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.client_configuration()
+        client_config = tlslib.TLSClientConfiguration()
 
         for dhc, dv in ((True, True), (True, False), (False, False)):
             with self.assertWarns(SecurityWarning):
-                insecure_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.insecure_configuration(
-                    dhc, dv
-                )
+                insecure_config = insecure.InsecureConfiguration(dhc, dv)
 
             with self.assertWarns(SecurityWarning):
                 insecure_client_context = (
@@ -208,13 +196,11 @@ class TestBuffer(TestInsecureBackend):
                 _ = insecure_client_context.create_buffer("localhost")
 
     def test_create_server_buffer_insecure(self):
-        server_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.server_configuration()
+        server_config = tlslib.TLSServerConfiguration()
 
         for dhc, dv in ((True, True), (True, False), (False, False)):
             with self.assertWarns(SecurityWarning):
-                insecure_config = stdlib_insecure.STDLIB_INSECURE_BACKEND.insecure_configuration(
-                    dhc, dv
-                )
+                insecure_config = insecure.InsecureConfiguration(dhc, dv)
 
             with self.assertWarns(SecurityWarning):
                 insecure_server_context = (

--- a/test/test_stdlib.py
+++ b/test/test_stdlib.py
@@ -21,16 +21,16 @@ from ._utils import (
 )
 
 
-class TestOpenSSLTrustStore(TestCase):
+class TestTrustStore(TestCase):
     def test_init(self):
         path = Path("/tmp/not-real")
-        store = stdlib.OpenSSLTrustStore(path)
-        self.assertEqual(store._trust_path, path)
+        store = tlslib.TrustStore(path=path)
+        self.assertEqual(store._path, path)
 
-        system_store = stdlib.OpenSSLTrustStore()
+        system_store = tlslib.TrustStore()
         self.assertNotEqual(store, system_store)
 
-        system_store_explicit = stdlib.OpenSSLTrustStore(None)
+        system_store_explicit = tlslib.TrustStore(None)
         self.assertNotEqual(store, system_store_explicit)
 
         # Separate instantiations of the same store (even the system store)
@@ -38,8 +38,8 @@ class TestOpenSSLTrustStore(TestCase):
         self.assertNotEqual(system_store, system_store_explicit)
 
     def test_system_store_method(self):
-        system_store = stdlib.OpenSSLTrustStore.system()
-        system_store_init = stdlib.OpenSSLTrustStore()
+        system_store = tlslib.TrustStore.system()
+        system_store_init = tlslib.TrustStore()
 
         # Separate instantiations of the  system store not equal.
         self.assertNotEqual(system_store, system_store_init)
@@ -55,11 +55,11 @@ class TestBackend(TestCase):
     def test_backend_types(self):
         backend = stdlib.STDLIB_BACKEND
 
-        self.assertIs(backend.certificate, stdlib.OpenSSLCertificate)
+        self.assertIs(backend.certificate, tlslib.Certificate)
         self.assertIs(backend.client_context, stdlib.OpenSSLClientContext)
-        self.assertIs(backend.private_key, stdlib.OpenSSLPrivateKey)
+        self.assertIs(backend.private_key, tlslib.PrivateKey)
         self.assertIs(backend.server_context, stdlib.OpenSSLServerContext)
-        self.assertIs(backend.trust_store, stdlib.OpenSSLTrustStore)
+        self.assertIs(backend.trust_store, tlslib.TrustStore)
 
         # invariant properties
         self.assertIs(backend.client_configuration, tlslib.TLSClientConfiguration)
@@ -88,7 +88,7 @@ class TestBasic(TestBackend):
             self.assertEqual(client_sock.cipher(), tlslib.CipherSuite.TLS_AES_256_GCM_SHA384)
             self.assertEqual(client_sock.negotiated_protocol(), None)
             self.assertEqual(client_sock.getpeername(), server.socket.getsockname())
-            self.assertIsInstance(client_sock.getpeercert(), stdlib.OpenSSLCertificate)
+            self.assertIsInstance(client_sock.getpeercert(), tlslib.Certificate)
             self.assertIsInstance(client_sock.fileno(), int)
 
             while True:
@@ -175,8 +175,9 @@ class TestConfig(TestBackend):
         server, client_config = limbo_server("webpki::san::exact-localhost-ip-san")
         # Add the server's signing certificate to the server's trust store, just so that it's not
         # empty
-        truststore = stdlib.OpenSSLTrustStore.from_file(
-            server.server_context.configuration.certificate_chain[0].leaf[0]._cert_path
+
+        truststore = tlslib.TrustStore.from_buffer(
+            server.server_context.configuration.certificate_chain[0].leaf[0]._buffer
         )
         server = tweak_server_config(server, trust_store=truststore)
 
@@ -192,7 +193,7 @@ class TestConfig(TestBackend):
 
     def test_config_explicit_system_trust_store_server(self):
         server, client_config = limbo_server("webpki::san::exact-localhost-ip-san")
-        truststore = stdlib.OpenSSLTrustStore(None)
+        truststore = tlslib.TrustStore()
         server = tweak_server_config(server, trust_store=truststore)
 
         with server:
@@ -252,14 +253,25 @@ class TestConfig(TestBackend):
                 client_sock.close(True)
 
     def test_config_signingchain_empty(self):
-        cert = stdlib.OpenSSLCertificate.from_buffer(b"")
-        key = stdlib.OpenSSLPrivateKey.from_buffer(b"")
+        cert = tlslib.Certificate.from_buffer(b"")
+        key = tlslib.PrivateKey.from_buffer(b"")
         tlslib.SigningChain((cert, key), None)
 
         with tempfile.NamedTemporaryFile(mode="wb") as empty_file:
-            cert = stdlib.OpenSSLCertificate.from_file(Path(empty_file.name))
-            key = stdlib.OpenSSLPrivateKey.from_file(Path(empty_file.name))
+            cert = tlslib.Certificate.from_file(Path(empty_file.name))
+            key = tlslib.PrivateKey.from_file(Path(empty_file.name))
             tlslib.SigningChain((cert, key), None)
+
+    def test_context_signingchain_path(self):
+        backend = stdlib.STDLIB_BACKEND
+        with tempfile.NamedTemporaryFile(mode="wb") as empty_file:
+            cert = tlslib.Certificate.from_file(Path(empty_file.name))
+            key = tlslib.PrivateKey.from_file(Path(empty_file.name))
+            sign_chain = tlslib.SigningChain((cert, key), (cert,))
+            server_config = backend.server_configuration(certificate_chain=(sign_chain,))
+            server_context = backend.server_context(server_config)
+            with self.assertRaises(tlslib.TLSError):
+                server_context.create_buffer()
 
 
 class TestNegative(TestBackend):
@@ -336,12 +348,52 @@ class TestNegative(TestBackend):
         backend = stdlib.STDLIB_BACKEND
 
         with self.assertRaises(NotImplementedError):
-            backend.trust_store.from_id(b"")
-        with self.assertRaises(NotImplementedError):
-            backend.certificate.from_id(b"")
+            trust_store = backend.trust_store.from_id(b"")
+            client_config = backend.client_configuration(trust_store=trust_store)
+            client_context = backend.client_context(client_config)
+            client_context.create_buffer("test")
 
         with self.assertRaises(NotImplementedError):
-            backend.private_key.from_id(b"")
+            certificate = backend.certificate.from_id(b"")
+            signing_chain = tlslib.SigningChain((certificate, None))
+            server_config = backend.server_configuration(certificate_chain=(signing_chain,))
+            server_context = backend.server_context(server_config)
+            server_context.create_buffer()
+
+        with self.assertRaises(NotImplementedError):
+            privkey = backend.private_key.from_id(b"")
+            certificate = backend.certificate.from_file(Path("/tmp/not-real"))
+            signing_chain = tlslib.SigningChain((certificate, privkey))
+            server_config = backend.server_configuration(certificate_chain=(signing_chain,))
+            server_context = backend.server_context(server_config)
+            server_context.create_buffer()
+
+    def test_empty_cert(self):
+        backend = stdlib.STDLIB_BACKEND
+        with self.assertRaises(ValueError):
+            certificate = backend.certificate.from_id(b"")
+            certificate._id = None
+            signing_chain = tlslib.SigningChain((certificate, None))
+            server_config = backend.server_configuration(certificate_chain=(signing_chain,))
+            server_context = backend.server_context(server_config)
+            server_context.create_buffer()
+
+        with self.assertRaises(NotImplementedError):
+            cert1 = backend.certificate.from_buffer(b"")
+            cert2 = backend.certificate.from_id(b"")
+            signing_chain = tlslib.SigningChain((cert1, None), (cert2,))
+            server_config = backend.server_configuration(certificate_chain=(signing_chain,))
+            server_context = backend.server_context(server_config)
+            server_context.create_buffer()
+
+        with self.assertRaises(ValueError):
+            cert1 = backend.certificate.from_buffer(b"")
+            cert2 = backend.certificate.from_id(b"")
+            cert2._id = None
+            signing_chain = tlslib.SigningChain((cert1, None), (cert2,))
+            server_config = backend.server_configuration(certificate_chain=(signing_chain,))
+            server_context = backend.server_context(server_config)
+            server_context.create_buffer()
 
 
 class TestClientAgainstSSL(TestBackend):
@@ -366,7 +418,7 @@ class TestClientAgainstSSL(TestBackend):
             self.assertEqual(client_sock.cipher(), tlslib.CipherSuite.TLS_AES_256_GCM_SHA384)
             self.assertEqual(client_sock.negotiated_protocol(), None)
             self.assertEqual(client_sock.getpeername(), server.socket.getsockname())
-            self.assertIsInstance(client_sock.getpeercert(), stdlib.OpenSSLCertificate)
+            self.assertIsInstance(client_sock.getpeercert(), tlslib.Certificate)
             self.assertIsInstance(client_sock.fileno(), int)
 
             client_sock.close(True)

--- a/test/test_stdlib.py
+++ b/test/test_stdlib.py
@@ -332,6 +332,17 @@ class TestNegative(TestBackend):
             with self.assertRaises(tlslib.WantWriteError):
                 client_sock.send(b"a" * 10000000)
 
+    def test_arbitrary_id_not_supported(self):
+        backend = stdlib.STDLIB_BACKEND
+
+        with self.assertRaises(NotImplementedError):
+            backend.trust_store.from_id(b"")
+        with self.assertRaises(NotImplementedError):
+            backend.certificate.from_id(b"")
+
+        with self.assertRaises(NotImplementedError):
+            backend.private_key.from_id(b"")
+
 
 class TestClientAgainstSSL(TestBackend):
     def test_trivial_connection_ssl(self):

--- a/test/test_stdlib.py
+++ b/test/test_stdlib.py
@@ -346,10 +346,10 @@ class TestNegative(TestBackend):
         # Trust store with arbitrary ID
         trust_store = tlslib.TrustStore.from_id(b"")
         client_config = tlslib.TLSClientConfiguration(trust_store=trust_store)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             backend.validate_config(client_config)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             client_context = backend.client_context(client_config)
             client_context.create_buffer("test")
 
@@ -358,10 +358,10 @@ class TestNegative(TestBackend):
         signing_chain = tlslib.SigningChain((certificate, None))
         server_config = tlslib.TLSServerConfiguration(certificate_chain=(signing_chain,))
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             backend.validate_config(server_config)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             server_context = backend.server_context(server_config)
             server_context.create_buffer()
 
@@ -371,10 +371,10 @@ class TestNegative(TestBackend):
         signing_chain = tlslib.SigningChain((cert1, None), (cert2,))
         server_config = tlslib.TLSServerConfiguration(certificate_chain=(signing_chain,))
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             backend.validate_config(server_config)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             server_context = backend.server_context(server_config)
             server_context.create_buffer()
 
@@ -384,10 +384,10 @@ class TestNegative(TestBackend):
         signing_chain = tlslib.SigningChain((certificate, privkey))
         server_config = tlslib.TLSServerConfiguration(certificate_chain=(signing_chain,))
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             backend.validate_config(server_config)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(tlslib.ConfigurationError):
             server_context = backend.server_context(server_config)
             server_context.create_buffer()
 
@@ -400,10 +400,10 @@ class TestNegative(TestBackend):
         signing_chain = tlslib.SigningChain((certificate, None))
         server_config = tlslib.TLSServerConfiguration(certificate_chain=(signing_chain,))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(tlslib.ConfigurationError):
             backend.validate_config(server_config)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(tlslib.ConfigurationError):
             server_context = backend.server_context(server_config)
             server_context.create_buffer()
 
@@ -414,10 +414,10 @@ class TestNegative(TestBackend):
         signing_chain = tlslib.SigningChain((cert1, None), (cert2,))
         server_config = tlslib.TLSServerConfiguration(certificate_chain=(signing_chain,))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(tlslib.ConfigurationError):
             backend.validate_config(server_config)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(tlslib.ConfigurationError):
             server_context = backend.server_context(server_config)
             server_context.create_buffer()
 

--- a/test/test_tlslib.py
+++ b/test/test_tlslib.py
@@ -9,38 +9,27 @@ from tlslib import tlslib
 
 class TestBackend(TestCase):
     def test_backend_types(self):
-        class Certificate:
-            pass
-
         class ClientContext:
-            pass
-
-        class PrivateKey:
             pass
 
         class ServerContext:
             pass
 
-        class TrustStore:
-            pass
+        def validate_config(
+            tls_config: tlslib.TLSClientConfiguration | tlslib.TLSServerConfiguration,
+        ) -> None:
+            return None
 
         backend = tlslib.Backend(
-            certificate=Certificate,
             client_context=ClientContext,
-            private_key=PrivateKey,
             server_context=ServerContext,
-            trust_store=TrustStore,
+            validate_config=validate_config,
         )
 
-        self.assertIs(backend.certificate, Certificate)
         self.assertIs(backend.client_context, ClientContext)
-        self.assertIs(backend.private_key, PrivateKey)
         self.assertIs(backend.server_context, ServerContext)
-        self.assertIs(backend.trust_store, TrustStore)
 
-        # invariant properties
-        self.assertIs(backend.client_configuration, tlslib.TLSClientConfiguration)
-        self.assertIs(backend.server_configuration, tlslib.TLSServerConfiguration)
+        self.assertIs(backend.validate_config, validate_config)
 
 
 class AbstractFunctions(TestBackend):
@@ -49,6 +38,11 @@ class AbstractFunctions(TestBackend):
             tlslib.TLSSocket.fileno(tlslib.TLSSocket)
 
     def test_pure_types(self):
+        self.assertIsInstance(tlslib.TrustStore.from_buffer(b""), tlslib.TrustStore)
+        self.assertIsInstance(tlslib.TrustStore.from_file(""), tlslib.TrustStore)
+        self.assertIsInstance(tlslib.TrustStore.from_id(b""), tlslib.TrustStore)
+        self.assertIsInstance(tlslib.TrustStore.from_id(b""), tlslib.TrustStore)
+        self.assertIsInstance(tlslib.TrustStore.system(), tlslib.TrustStore)
         self.assertIsInstance(tlslib.Certificate.from_buffer(b""), tlslib.Certificate)
         self.assertIsInstance(tlslib.Certificate.from_file(""), tlslib.Certificate)
         self.assertIsInstance(tlslib.Certificate.from_id(b""), tlslib.Certificate)
@@ -61,10 +55,5 @@ class AbstractFunctions(TestBackend):
             tlslib.PrivateKey()
 
     def test_empty_protocols(self):
-        tlslib.TrustStore.from_buffer(b"")
-        tlslib.TrustStore.from_file("")
-        tlslib.TrustStore.from_id(b"")
-        tlslib.TrustStore.from_id(b"")
-        tlslib.TrustStore.system()
         tlslib.ClientContext.__init__(tlslib.ClientContext, tlslib.TLSClientConfiguration())
         tlslib.ServerContext.__init__(tlslib.ClientContext, tlslib.TLSServerConfiguration())

--- a/test/test_tlslib.py
+++ b/test/test_tlslib.py
@@ -46,25 +46,19 @@ class TestBackend(TestCase):
 class AbstractFunctions(TestBackend):
     def test_not_implemented(self):
         with self.assertRaises(NotImplementedError):
-            tlslib.Certificate.from_buffer(b"")
-
-        with self.assertRaises(NotImplementedError):
-            tlslib.Certificate.from_file("")
-
-        with self.assertRaises(NotImplementedError):
-            tlslib.Certificate.from_id(b"")
-
-        with self.assertRaises(NotImplementedError):
-            tlslib.PrivateKey.from_buffer(b"")
-
-        with self.assertRaises(NotImplementedError):
-            tlslib.PrivateKey.from_file("")
-
-        with self.assertRaises(NotImplementedError):
-            tlslib.PrivateKey.from_id(b"")
-
-        with self.assertRaises(NotImplementedError):
             tlslib.TLSSocket.fileno(tlslib.TLSSocket)
+
+    def test_pure_types(self):
+        self.assertIsInstance(tlslib.Certificate.from_buffer(b""), tlslib.Certificate)
+        self.assertIsInstance(tlslib.Certificate.from_file(""), tlslib.Certificate)
+        self.assertIsInstance(tlslib.Certificate.from_id(b""), tlslib.Certificate)
+        self.assertIsInstance(tlslib.PrivateKey.from_buffer(b""), tlslib.PrivateKey)
+        self.assertIsInstance(tlslib.PrivateKey.from_file(""), tlslib.PrivateKey)
+        self.assertIsInstance(tlslib.PrivateKey.from_id(b""), tlslib.PrivateKey)
+        with self.assertRaises(ValueError):
+            tlslib.Certificate()
+        with self.assertRaises(ValueError):
+            tlslib.PrivateKey()
 
     def test_empty_protocols(self):
         tlslib.TrustStore.from_buffer(b"")

--- a/test/test_tlslib.py
+++ b/test/test_tlslib.py
@@ -52,10 +52,16 @@ class AbstractFunctions(TestBackend):
             tlslib.Certificate.from_file("")
 
         with self.assertRaises(NotImplementedError):
+            tlslib.Certificate.from_id(b"")
+
+        with self.assertRaises(NotImplementedError):
             tlslib.PrivateKey.from_buffer(b"")
 
         with self.assertRaises(NotImplementedError):
             tlslib.PrivateKey.from_file("")
+
+        with self.assertRaises(NotImplementedError):
+            tlslib.PrivateKey.from_id(b"")
 
         with self.assertRaises(NotImplementedError):
             tlslib.TLSSocket.fileno(tlslib.TLSSocket)
@@ -63,6 +69,7 @@ class AbstractFunctions(TestBackend):
     def test_empty_protocols(self):
         tlslib.TrustStore.from_buffer(b"")
         tlslib.TrustStore.from_file("")
+        tlslib.TrustStore.from_id(b"")
         tlslib.TrustStore.system()
         tlslib.ClientContext.__init__(tlslib.ClientContext, tlslib.TLSClientConfiguration())
         tlslib.ServerContext.__init__(tlslib.ClientContext, tlslib.TLSServerConfiguration())


### PR DESCRIPTION
This is my first stab at making the types pure, obviating the need for backend specific types. One downside seems to be that non-implemented interfaces of e.g. certificates only get revealed when trying to connect.

Closes #50.