### PR TITLE
Small fix for buffers

### DIFF
--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -9,6 +9,7 @@ from enum import Enum, IntEnum
 from typing import Generic, Protocol, TypeVar
 
 __all__ = [
+    "TLSBuffer",
     "TLSServerConfiguration",
     "TLSClientConfiguration",
     "ClientContext",
@@ -660,6 +661,12 @@ class TLSBuffer(Protocol):
         ``WantReadError`` and store no data. At this point, the user must
         call ``read`` to remove some data from the internal buffer
         before repeating this call.
+        """
+
+    @abstractmethod
+    def incoming_bytes_buffered(self) -> int:
+        """
+        Returns how many bytes are in the incoming buffer waiting to be processed.
         """
 
     @abstractmethod


### PR DESCRIPTION
Add `TLSBuffer` to `__all__` and add `incoming_bytes_buffered` to the `TLSBuffer` API (as opposed to just define it in the stdlib implementation).