### PR TITLE
Remove fileno from TLSSocket API

### DIFF
--- a/src/tlslib/tlslib.py
+++ b/src/tlslib/tlslib.py
@@ -501,11 +501,6 @@ class TLSSocket(Protocol):
     def getpeername(self) -> tuple[str | None, int]:
         """Return the remote address to which the socket is connected."""
 
-    def fileno(self) -> int:
-        """Return the socket’s file descriptor (a small integer), or -1 on failure."""
-
-        raise NotImplementedError("File descriptors from sockets not supported.")
-
     @property
     @abstractmethod
     def context(self) -> ClientContext | ServerContext:

--- a/test/test_tlslib.py
+++ b/test/test_tlslib.py
@@ -63,9 +63,6 @@ class AbstractFunctions(TestBackend):
         with self.assertRaises(NotImplementedError):
             tlslib.PrivateKey.from_id(b"")
 
-        with self.assertRaises(NotImplementedError):
-            tlslib.TLSSocket.fileno(tlslib.TLSSocket)
-
     def test_empty_protocols(self):
         tlslib.TrustStore.from_buffer(b"")
         tlslib.TrustStore.from_file("")


### PR DESCRIPTION
Concretely defining `fileno` in a `Protocol` may be problematic for backends that do not support it for sockets.